### PR TITLE
Skriv interne lenker på riktig format

### DIFF
--- a/content/pages/hvaskjer.mdx
+++ b/content/pages/hvaskjer.mdx
@@ -5,27 +5,27 @@ slug: /hva-skjer
 menu: 2
 ---
 
-# Hva skjer?  
-  
-[Trykk her for å lese våre regler](https://queerhangout/regler)  
-Hvis du har allergier, diett restriksjoner eller andre tilrettelegginsbehov, ta kontakt med oss på [queerhangout@posteo.no](mailto:queerhangout@posteo.no)  
-  
-## Strømsø Knutepunkt  
+# Hva skjer?
+
+[Trykk her for å lese våre regler](/regler)  
+Hvis du har allergier, diett restriksjoner eller andre tilrettelegginsbehov, ta kontakt med oss på [queerhangout@posteo.no](mailto:queerhangout@posteo.no)
+
+## Strømsø Knutepunkt
+
 Andre søndagen i måneden, 14:00-18:00.  
-Åpent for alle skeive. Rullestolvennlig, normal og HC parkering, har stillerom. (Rullestolbrukere har en alternativ inngang som er tilrettelagt)  
+Åpent for alle skeive. Rullestolvennlig, normal og HC parkering, har stillerom. (Rullestolbrukere har en alternativ inngang som er tilrettelagt)
 
-![Foto av inngangen til Strømsø Knutepunkt.](../images/stromso.jpeg "Strømsø Knutepunkt. Bilde tatt av Leona Imperatori")  
-  
-## Criollo sjokoladebar  
+![Foto av inngangen til Strømsø Knutepunkt.](../images/stromso.jpeg "Strømsø Knutepunkt. Bilde tatt av Leona Imperatori")
+
+## Criollo sjokoladebar
+
 Siste søndagen i måneden, 14:00-17:00.  
-Åpent for alle skeive. Rullestolvennlig, tendens til å bli høylydt.  
-  
-![Foto av fronten av Criollo Sjokoladebar. Det er et stort glassvegg som lener ut med logoen skrevet inn i skiven, men ord som "Plantebasert" og "økologisk" skrevet over. Inngangen er vedsidenav glassveggen, og har et skilt som sier "Flytogpassasjen" over inngangen.](../images/criollo.jpeg "Criollo Sjokoladebar. Bilde tatt av Leona Imperatori")  
+Åpent for alle skeive. Rullestolvennlig, tendens til å bli høylydt.
 
-  
-## Lukkede arrangementer  
-Vi har en lukket facebookgruppe der alle kan legge ut egne aktiviteter. For våre medlemmers sikkerhet, må du først dra til et av våre offentlige arrangementer for å få tilgang.  
+![Foto av fronten av Criollo Sjokoladebar. Det er et stort glassvegg som lener ut med logoen skrevet inn i skiven, men ord som "Plantebasert" og "økologisk" skrevet over. Inngangen er vedsidenav glassveggen, og har et skilt som sier "Flytogpassasjen" over inngangen.](../images/criollo.jpeg "Criollo Sjokoladebar. Bilde tatt av Leona Imperatori")
 
-  
+## Lukkede arrangementer
+
+Vi har en lukket facebookgruppe der alle kan legge ut egne aktiviteter. For våre medlemmers sikkerhet, må du først dra til et av våre offentlige arrangementer for å få tilgang.
+
 **Hjertlig velkommen**
-

--- a/content/pages/index.mdx
+++ b/content/pages/index.mdx
@@ -9,6 +9,6 @@ menu: 0
 
 Velkommen til **Queer Hangout.** Queer Hangout er en møteplass for skeive voksne i Drammen.
 
-[Les mer om oss her](https://queerhangout.no/om-oss)
+[Les mer om oss her](/om-oss)
 
-[Sjekk ut våre aktiviteter her](https://queerhangout.no/hva-skjer)
+[Sjekk ut våre aktiviteter her](/hva-skjer)


### PR DESCRIPTION
Interne lenker, altså lenker til andre siden på nettsiden, trenger ikke domenenavnet først, men kan skrives på formatet `/lenke-til-undersiden`.